### PR TITLE
feat: show colours and scores as $away at $home

### DIFF
--- a/Awtrix NFL Team Scoreboard/awtrix_nfl_team_scoreboard.yaml
+++ b/Awtrix NFL Team Scoreboard/awtrix_nfl_team_scoreboard.yaml
@@ -118,6 +118,21 @@ blueprint:
           unit_of_measurement: "sec"
       default: 130
 
+    display_mode:
+      name: Display Mode
+      description: >-
+        Choose how teams are displayed: 
+        'ESPN default' - Selected Team is on the left, Other Team is on the right  
+        'Traditional' - Away Team At Home Team
+      default: "my_team_left"
+      selector:
+        select:
+          options:
+            - label: "ESPN default"
+              value: "my_team_left"
+            - label: "Traditional"
+              value: "home_team_right"
+
   source_url: https://raw.githubusercontent.com/jlongman/Homeassistant_blueprints/main/Awtrix%20NFL%20Team%20Scoreboard/awtrix_nfl_team_scoreboard.yaml
 
 variables:
@@ -135,6 +150,7 @@ variables:
   appname: !input appname
   my_sensor: !input my_sensor
   my_timer: !input my_timer
+  display_mode: !input display_mode
   message_duration: !input message_duration
   message_lifetime: !input message_lifetime
   date_stripper: "{{ [ now().month, '/', now().day, ' - '] | join('') }}"
@@ -143,6 +159,93 @@ variables:
   my_timer_overtime_intermission: !input my_timer_overtime_intermission
   intermission_1st_time: "{{ my_timer_1st_2nd_intermission }}"
   intermission_3rd_time: "{% if my_timer_overtime_intermission > 0 %}{{ my_timer_overtime_intermission }}{% else %}{{ my_timer_1st_2nd_intermission }}{% endif %}"
+  is_swapped: "{% if display_mode == 'home_team_right' %}{{ state_attr(my_sensor, 'team_homeaway') == 'home' }}{% else %}false{% endif %}"
+  left_team_colors_0: >-
+    {% if is_swapped %}
+      {% if state_attr(my_sensor, 'opponent_abbr') == 'CAN' %}#D80621
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'SWE' %}#006AA7
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'USA' %}#0A3161
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'FIN' %}#002F6C
+      {% else %}{{ state_attr(my_sensor, 'opponent_colors')[0] }}
+      {% endif %}
+    {% else %}
+      {% if state_attr(my_sensor, 'team_abbr') == 'CAN' %}#D80621
+      {% elif state_attr(my_sensor, 'team_abbr') == 'SWE' %}#006AA7
+      {% elif state_attr(my_sensor, 'team_abbr') == 'USA' %}#0A3161
+      {% elif state_attr(my_sensor, 'team_abbr') == 'FIN' %}#002F6C
+      {% else %}{{ state_attr(my_sensor, 'team_colors')[0] }}
+      {% endif %}
+    {% endif %}
+  left_team_colors_1: >-
+    {% if is_swapped %}
+      {% if state_attr(my_sensor, 'opponent_abbr') == 'CAN' %}#FFFFFF
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'SWE' %}#FECC02
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'USA' %}#B31942
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'FIN' %}#FFFFFF
+      {% else %}{{ state_attr(my_sensor, 'opponent_colors')[1] }}
+      {% endif %}
+    {% else %}
+      {% if state_attr(my_sensor, 'team_abbr') == 'CAN' %}#FFFFFF
+      {% elif state_attr(my_sensor, 'team_abbr') == 'SWE' %}#FECC02
+      {% elif state_attr(my_sensor, 'team_abbr') == 'USA' %}#B31942
+      {% elif state_attr(my_sensor, 'team_abbr') == 'FIN' %}#FFFFFF
+      {% else %}{{ state_attr(my_sensor, 'team_colors')[1] }}
+      {% endif %}
+    {% endif %}
+  right_team_colors_0: >-
+    {% if is_swapped %}
+      {% if state_attr(my_sensor, 'team_abbr') == 'CAN' %}#D80621
+      {% elif state_attr(my_sensor, 'team_abbr') == 'SWE' %}#006AA7
+      {% elif state_attr(my_sensor, 'team_abbr') == 'USA' %}#0A3161
+      {% elif state_attr(my_sensor, 'team_abbr') == 'FIN' %}#002F6C
+      {% else %}{{ state_attr(my_sensor, 'team_colors')[0] }}
+      {% endif %}
+    {% else %}
+      {% if state_attr(my_sensor, 'opponent_abbr') == 'CAN' %}#D80621
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'SWE' %}#006AA7
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'USA' %}#0A3161
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'FIN' %}#002F6C
+      {% else %}{{ state_attr(my_sensor, 'opponent_colors')[0] }}
+      {% endif %}
+    {% endif %}
+  right_team_colors_1: >-
+    {% if is_swapped %}
+      {% if state_attr(my_sensor, 'team_abbr') == 'CAN' %}#FFFFFF
+      {% elif state_attr(my_sensor, 'team_abbr') == 'SWE' %}#FECC02
+      {% elif state_attr(my_sensor, 'team_abbr') == 'USA' %}#B31942
+      {% elif state_attr(my_sensor, 'team_abbr') == 'FIN' %}#FFFFFF
+      {% else %}{{ state_attr(my_sensor, 'team_colors')[1] }}
+      {% endif %}
+    {% else %}
+      {% if state_attr(my_sensor, 'opponent_abbr') == 'CAN' %}#FFFFFF
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'SWE' %}#FECC02
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'USA' %}#B31942
+      {% elif state_attr(my_sensor, 'opponent_abbr') == 'FIN' %}#FFFFFF
+      {% else %}{{ state_attr(my_sensor, 'opponent_colors')[1] }}
+      {% endif %}
+    {% endif %}
+  left_team_score: >-
+    {% if is_swapped %}
+      {% set raw_score = state_attr(my_sensor, 'opponent_score') %}
+    {% else %}
+      {% set raw_score = state_attr(my_sensor, 'team_score') %}
+    {% endif %}
+    {% if raw_score|int < 10 %}
+      {{ "0" + raw_score|string }}
+    {% else %}
+      {{ raw_score|string }}
+    {% endif %}
+  right_team_score: >-
+    {% if is_swapped %}
+      {% set raw_score = state_attr(my_sensor, 'team_score') %}
+    {% else %}
+      {% set raw_score = state_attr(my_sensor, 'opponent_score') %}
+    {% endif %}
+    {% if raw_score|int < 10 %}
+      {{ "0" + raw_score|string }}
+    {% else %}
+      {{ raw_score|string }}
+    {% endif %}
   team_colors_0: >-
     {% if state_attr(my_sensor, 'team_abbr') == 'CAN' %}#D80621
     {% elif state_attr(my_sensor, 'team_abbr') == 'SWE' %}#006AA7
@@ -214,12 +317,12 @@ variables:
   payload_game_prestart: >-
     {
       "draw":[ 
-        {"df":[0,0,16,8,"{{ team_colors_0 }}"]},
-        {"df":[16,0,16,8,"{{ opponent_colors_0 }}"]},
-        {"dl":[3,0,1,7,"{{ team_colors_1 }}"]},
-        {"dl":[5,0,3,7,"{{ team_colors_1 }}"]},
-        {"dl":[28,0,28,7,"{{ opponent_colors_1 }}"]},
-        {"dl":[30,0,30,7,"{{ opponent_colors_1 }}"]}
+        {"df":[0,0,16,8,"{{ left_team_colors_0 }}"]},
+        {"df":[16,0,16,8,"{{ right_team_colors_0 }}"]},
+        {"dl":[3,0,1,7,"{{ left_team_colors_1 }}"]},
+        {"dl":[5,0,3,7,"{{ left_team_colors_1 }}"]},
+        {"dl":[28,0,28,7,"{{ right_team_colors_1 }}"]},
+        {"dl":[30,0,30,7,"{{ right_team_colors_1 }}"]}
       ],
       "text": " {{ game_clock | replace( date_stripper | join, '') | regex_replace(timezone_regex, '') }}{{' - '}}{{- pregame_notice -}}",
       "topText": "true",
@@ -229,15 +332,15 @@ variables:
   payload_game_start: >-
     {
       "draw":[ 
-        {"df":[0,0,16,8,"{{ team_colors_0 }}"]},     
-        {"df":[16,0,16,8,"{{ opponent_colors_0 }}"]}, 
-        {"dl":[1,0,1,7,"{{ team_colors_1 }}"]},
-        {"dl":[3,0,3,7,"{{ team_colors_1 }}"]},
-        {"dl":[28,0,28,7,"{{ opponent_colors_1 }}"]}, 
-        {"dl":[30,0,30,7,"{{ opponent_colors_1 }}"]}, 
+        {"df":[0,0,16,8,"{{ left_team_colors_0 }}"]},     
+        {"df":[16,0,16,8,"{{ right_team_colors_0 }}"]}, 
+        {"dl":[1,0,1,7,"{{ left_team_colors_1 }}"]},
+        {"dl":[3,0,3,7,"{{ left_team_colors_1 }}"]},
+        {"dl":[28,0,28,7,"{{ right_team_colors_1 }}"]}, 
+        {"dl":[30,0,30,7,"{{ right_team_colors_1 }}"]}, 
         {{ first_quarter }}
-        {"dt":[7, 1, "{{ team_score }}",[255,255,255]]}, 
-        {"dt":[18, 1, "{{ opponent_score }}",[255,255,255]]}, 
+        {"dt":[7, 1, "{{ left_team_score }}",[255,255,255]]}, 
+        {"dt":[18, 1, "{{ right_team_score }}",[255,255,255]]}, 
         {"dl":[15,3,16,3,"#ffffff"]} 
       ], 
       "duration": {{ message_duration }} 
@@ -245,15 +348,15 @@ variables:
   payload_second_quarter: >-
     {
       "draw":[ 
-        {"df":[0,0,16,8,"{{ team_colors_0 }}"]},     
-        {"df":[16,0,16,8,"{{ opponent_colors_0 }}"]}, 
-        {"dl":[1,0,1,7,"{{ team_colors_1 }}"]},
-        {"dl":[3,0,3,7,"{{ team_colors_1 }}"]},
-        {"dl":[28,0,28,7,"{{ opponent_colors_1 }}"]}, 
-        {"dl":[30,0,30,7,"{{ opponent_colors_1 }}"]}, 
+        {"df":[0,0,16,8,"{{ left_team_colors_0 }}"]},     
+        {"df":[16,0,16,8,"{{ right_team_colors_0 }}"]}, 
+        {"dl":[1,0,1,7,"{{ left_team_colors_1 }}"]},
+        {"dl":[3,0,3,7,"{{ left_team_colors_1 }}"]},
+        {"dl":[28,0,28,7,"{{ right_team_colors_1 }}"]}, 
+        {"dl":[30,0,30,7,"{{ right_team_colors_1 }}"]}, 
         {{ second_quarter }}
-        {"dt":[7, 1, "{{ team_score }}",[255,255,255]]}, 
-        {"dt":[18, 1, "{{ opponent_score }}",[255,255,255]]}, 
+        {"dt":[7, 1, "{{ left_team_score }}",[255,255,255]]}, 
+        {"dt":[18, 1, "{{ right_team_score }}",[255,255,255]]}, 
         {"dl":[15,3,16,3,"#ffffff"]} 
       ], 
       "duration": {{ message_duration }} 
@@ -261,15 +364,15 @@ variables:
   payload_third_quarter: >-
     {
       "draw":[ 
-        {"df":[0,0,16,8,"{{ team_colors_0 }}"]},     
-        {"df":[16,0,16,8,"{{ opponent_colors_0 }}"]}, 
-        {"dl":[1,0,1,7,"{{ team_colors_1 }}"]},
-        {"dl":[3,0,3,7,"{{ team_colors_1 }}"]},
-        {"dl":[28,0,28,7,"{{ opponent_colors_1 }}"]}, 
-        {"dl":[30,0,30,7,"{{ opponent_colors_1 }}"]}, 
+        {"df":[0,0,16,8,"{{ left_team_colors_0 }}"]},     
+        {"df":[16,0,16,8,"{{ right_team_colors_0 }}"]}, 
+        {"dl":[1,0,1,7,"{{ left_team_colors_1 }}"]},
+        {"dl":[3,0,3,7,"{{ left_team_colors_1 }}"]},
+        {"dl":[28,0,28,7,"{{ right_team_colors_1 }}"]}, 
+        {"dl":[30,0,30,7,"{{ right_team_colors_1 }}"]}, 
         {{ third_quarter }}
-        {"dt":[7, 1, "{{ team_score }}",[255,255,255]]}, 
-        {"dt":[18, 1, "{{ opponent_score }}",[255,255,255]]}, 
+        {"dt":[7, 1, "{{ left_team_score }}",[255,255,255]]}, 
+        {"dt":[18, 1, "{{ right_team_score }}",[255,255,255]]}, 
         {"dl":[15,3,16,3,"#ffffff"]} 
       ], 
       "duration": {{ message_duration }} 
@@ -277,15 +380,15 @@ variables:
   payload_fourth_quarter: >-
     {
       "draw":[ 
-        {"df":[0,0,16,8,"{{ team_colors_0 }}"]},     
-        {"df":[16,0,16,8,"{{ opponent_colors_0 }}"]}, 
-        {"dl":[1,0,1,7,"{{ team_colors_1 }}"]},
-        {"dl":[3,0,3,7,"{{ team_colors_1 }}"]},
-        {"dl":[28,0,28,7,"{{ opponent_colors_1 }}"]}, 
-        {"dl":[30,0,30,7,"{{ opponent_colors_1 }}"]}, 
+        {"df":[0,0,16,8,"{{ left_team_colors_0 }}"]},     
+        {"df":[16,0,16,8,"{{ right_team_colors_0 }}"]}, 
+        {"dl":[1,0,1,7,"{{ left_team_colors_1 }}"]},
+        {"dl":[3,0,3,7,"{{ left_team_colors_1 }}"]},
+        {"dl":[28,0,28,7,"{{ right_team_colors_1 }}"]}, 
+        {"dl":[30,0,30,7,"{{ right_team_colors_1 }}"]}, 
         {{ fourth_quarter }}
-        {"dt":[7, 1, "{{ team_score }}",[255,255,255]]}, 
-        {"dt":[18, 1, "{{ opponent_score }}",[255,255,255]]}, 
+        {"dt":[7, 1, "{{ left_team_score }}",[255,255,255]]}, 
+        {"dt":[18, 1, "{{ right_team_score }}",[255,255,255]]}, 
         {"dl":[15,3,16,3,"#ffffff"]} 
       ], 
       "duration": {{ message_duration }} 


### PR DESCRIPTION
This pull request adds a new display mode option to the Awtrix NFL Team Scoreboard blueprint, allowing users to choose how teams are displayed (either ESPN default or traditional away/home format). It introduces supporting variables and logic to dynamically swap team positions, colors, and scores in the display payloads based on the selected mode. This makes the scoreboard more flexible and customizable for different user preferences.

**Display Mode Feature:**

* Added a new `display_mode` input to the blueprint, allowing users to select between "ESPN default" (selected team on the left) and "Traditional" (away team at home team) display formats.
* Introduced the `is_swapped` variable and supporting logic to determine team placement, colors, and scores based on the chosen display mode. [[1]](diffhunk://#diff-8cca746642c69b498ca19dd69e8595c525c7081e48a7bff8f177bd286e831808R153) [[2]](diffhunk://#diff-8cca746642c69b498ca19dd69e8595c525c7081e48a7bff8f177bd286e831808R162-R248)

**Dynamic Team Display Logic:**

* Added new variables (`left_team_colors_0`, `left_team_colors_1`, `right_team_colors_0`, `right_team_colors_1`, `left_team_score`, `right_team_score`) to dynamically assign colors and scores to the left and right teams, depending on the display mode and team attributes.

**Payload Updates:**

* Updated all game payload sections (`payload_game_prestart`, `payload_game_start`, `payload_second_quarter`, `payload_third_quarter`, `payload_fourth_quarter`) to use the new left/right team variables for colors and scores, ensuring the display matches the selected mode. [[1]](diffhunk://#diff-8cca746642c69b498ca19dd69e8595c525c7081e48a7bff8f177bd286e831808L217-R325) [[2]](diffhunk://#diff-8cca746642c69b498ca19dd69e8595c525c7081e48a7bff8f177bd286e831808L232-R391)

---

Still looking for a means to use macros to compress the code, colour lookups suck.