### PR TITLE
Mlb

### DIFF
--- a/Awtrix MLB Team Scoreboard/awtrix_mlb_team_scoreboard.yaml
+++ b/Awtrix MLB Team Scoreboard/awtrix_mlb_team_scoreboard.yaml
@@ -317,7 +317,6 @@ variables:
         {% else %}
           {"df":[0,0,16,8,"{{ left_team_colors_0 }}"]},
           {"df":[16,0,16,8,"{{ right_team_colors_0 }}"]},
-          {"dp":[16,0,"#00FF00"]},
         {% endif %}
 
         {"dl":[1,0,1,7,"{{ left_team_colors_1 }}"]},
@@ -330,11 +329,6 @@ variables:
         {% if bases_display|trim %},{{ bases_display }}{% endif %}
         {% if outs_display|trim %},{{ outs_display }}{% endif %}
         ,{{ inning_line }}
-        {% if is_swapped %}
-        ,{"dp":[0,0,"#FF0000"]}
-        {% else %}
-        ,{"dp":[0,0,"#0000FF"]}
-        {% endif %}
       ],
       "duration": {{ message_duration }}
     }

--- a/Awtrix MLB Team Scoreboard/awtrix_mlb_team_scoreboard.yaml
+++ b/Awtrix MLB Team Scoreboard/awtrix_mlb_team_scoreboard.yaml
@@ -274,11 +274,7 @@ variables:
     {% if use_custom_one %}
       {% set s = left_team_score | int %}
       {% if s < 10 %}
-        {% if s == 1 %}
-          {"dp":[5,1,"#FFFFFF"]},{"dl":[6,1,6,5,"#FFFFFF"]}
-        {% else %}
-          {"dt":[5,1,"{{ s }}",[255,255,255]]}
-        {% endif %}
+        {"dt":[5,1,"{{ s }}",[255,255,255]]}
       {% elif s >= 10 and s <= 19 %}
         {% set ones = s % 10 %}
         {"dp":[2,1,"#FFFFFF"]},{"dl":[3,1,3,5,"#FFFFFF"]},
@@ -295,11 +291,7 @@ variables:
     {% if use_custom_one %}
       {% set s = right_team_score | int %}
       {% if s < 10 %}
-        {% if s == 1 %}
-          {"dp":[23,1,"#FFFFFF"]},{"dl":[24,1,24,5,"#FFFFFF"]}
-        {% else %}
-          {"dt":[26,1,"{{ s }}",[255,255,255]]}
-        {% endif %}
+        {"dt":[24,1,"{{ s }}",[255,255,255]]}
       {% elif s >= 10 and s <= 19 %}
         {% set ones = s % 10 %}
         {"dp":[23,1,"#FFFFFF"]},{"dl":[24,1,24,5,"#FFFFFF"]},

--- a/Awtrix MLB Team Scoreboard/awtrix_mlb_team_scoreboard.yaml
+++ b/Awtrix MLB Team Scoreboard/awtrix_mlb_team_scoreboard.yaml
@@ -211,17 +211,25 @@ variables:
       {% set ball1 = mlb_balls >= 1 %}
       {% set ball2 = mlb_balls >= 2 %}
       {% set ball3 = mlb_balls >= 3 %}
+      {% set ball4 = mlb_balls >= 4 %}
       {{ '{"dp":[21,0, "#FFEA00"]},' if ball1 else '{"dp":[21,0,"#5F5F5F"]},' }}
       {{ '{"dp":[21,1, "#FFEA00"]},' if ball2 else '{"dp":[21,1,"#5F5F5F"]},' }}
       {{ '{"dp":[21,2, "#FFEA00"]}' if ball3 else '{"dp":[21,2,"#5F5F5F"]}' }}
+      {% if ball4 %}
+      ,{"dp":[21,3, "#FFEA00"]}
+      {% endif %}
     {% endif %}
 
   strikes_display: >-
     {% if not is_middle_inning %}
       {% set strike1 = mlb_strikes >= 1 %}
       {% set strike2 = mlb_strikes >= 2 %}
+      {% set strike3 = mlb_strikes >= 3 %}
       {{ '{"dp":[21,4, "#FF0000"]},' if strike1 else '{"dp":[21,4,"#5F5F5F"]},' }}
       {{ '{"dp":[21,5, "#FF0000"]}' if strike2 else '{"dp":[21,5,"#5F5F5F"]}' }}
+      {% if strike3 %}
+      ,{"dp":[21,6, "#FF0000"]}
+      {% endif %}
     {% endif %}
 
   # --- MLB Phase 3: Bases display (diamond in middle section during active at-bat) ---

--- a/Awtrix MLB Team Scoreboard/awtrix_mlb_team_scoreboard.yaml
+++ b/Awtrix MLB Team Scoreboard/awtrix_mlb_team_scoreboard.yaml
@@ -309,6 +309,9 @@ variables:
       {% set s = left_team_score | int %}
       {% if s < 10 %}
         {"dt":[5,1,"{{ s }}",[255,255,255]]}
+      {% elif s == 11 %}
+        {"dp":[2,1,"#FFFFFF"]},{"dl":[3,1,3,5,"#FFFFFF"]},
+        {"dp":[5,1,"#FFFFFF"]},{"dl":[6,1,6,5,"#FFFFFF"]}
       {% elif s >= 10 and s <= 19 %}
         {% set ones = s % 10 %}
         {"dp":[2,1,"#FFFFFF"]},{"dl":[3,1,3,5,"#FFFFFF"]},
@@ -326,6 +329,9 @@ variables:
       {% set s = right_team_score | int %}
       {% if s < 10 %}
         {"dt":[24,1,"{{ s }}",[255,255,255]]}
+      {% elif s == 11 %}
+        {"dp":[23,1,"#FFFFFF"]},{"dl":[24,1,24,5,"#FFFFFF"]},
+        {"dp":[26,1,"#FFFFFF"]},{"dl":[27,1,27,5,"#FFFFFF"]}
       {% elif s >= 10 and s <= 19 %}
         {% set ones = s % 10 %}
         {"dp":[23,1,"#FFFFFF"]},{"dl":[24,1,24,5,"#FFFFFF"]},

--- a/Awtrix MLB Team Scoreboard/awtrix_mlb_team_scoreboard.yaml
+++ b/Awtrix MLB Team Scoreboard/awtrix_mlb_team_scoreboard.yaml
@@ -185,6 +185,14 @@ variables:
     {% if state_attr(my_sensor, 'on_third')  is not none %}
     {{ state_attr(my_sensor, 'on_third') | default(false) | bool }}
     {% else %}{{ false | bool }}{% endif %}
+  mlb_balls: >-
+    {% if state_attr(my_sensor, 'balls')  is not none %}
+    {{ state_attr(my_sensor, 'balls') | int(0) }}
+    {% else %}0{% endif %}
+  mlb_strikes: >-
+    {% if state_attr(my_sensor, 'strikes')  is not none %}
+    {{ state_attr(my_sensor, 'strikes') | int(0) }}
+    {% else %}0{% endif %}
   # TeamTracker uses 'quarter' for inning number in MLB
   mlb_inning: >-
     {% if state_attr(my_sensor, 'quarter')  is not none %}
@@ -197,6 +205,24 @@ variables:
   is_top_inning: "{{ (mlb_clock | string | lower) is match('^top') }}"
   is_bottom_inning: "{{ (mlb_clock | string | lower) is match('^bottom') }}"
   is_middle_inning: "{{ (mlb_clock | string | lower) is match('^middle') or (mlb_clock | string | lower) is match('^end') }}"
+
+  balls_display: >-
+    {% if not is_middle_inning %}
+      {% set ball1 = mlb_balls >= 1 %}
+      {% set ball2 = mlb_balls >= 2 %}
+      {% set ball3 = mlb_balls >= 3 %}
+      {{ '{"dp":[21,0, "#FFEA00"]},' if ball1 else '{"dp":[21,0,"#5F5F5F"]},' }}
+      {{ '{"dp":[21,1, "#FFEA00"]},' if ball2 else '{"dp":[21,1,"#5F5F5F"]},' }}
+      {{ '{"dp":[21,2, "#FFEA00"]}' if ball3 else '{"dp":[21,2,"#5F5F5F"]}' }}
+    {% endif %}
+
+  strikes_display: >-
+    {% if not is_middle_inning %}
+      {% set strike1 = mlb_strikes >= 1 %}
+      {% set strike2 = mlb_strikes >= 2 %}
+      {{ '{"dp":[21,4, "#FF0000"]},' if strike1 else '{"dp":[21,4,"#5F5F5F"]},' }}
+      {{ '{"dp":[21,5, "#FF0000"]}' if strike2 else '{"dp":[21,5,"#5F5F5F"]}' }}
+    {% endif %}
 
   # --- MLB Phase 3: Bases display (diamond in middle section during active at-bat) ---
   bases_display: >-
@@ -328,6 +354,8 @@ variables:
         {{ right_score_draw }}
         {% if bases_display|trim %},{{ bases_display }}{% endif %}
         {% if outs_display|trim %},{{ outs_display }}{% endif %}
+        {% if balls_display|trim %},{{ balls_display }}{% endif %}
+        {% if strikes_display|trim %},{{ strikes_display }}{% endif %}
         ,{{ inning_line }}
       ],
       "duration": {{ message_duration }}
@@ -445,6 +473,15 @@ triggers:
     entity_id: !input my_sensor
     attribute: on_third
     id: MLB Third Base Change
+  - trigger: state
+    entity_id: !input my_sensor
+    attribute: balls
+    id: MLB Balls Change
+  - trigger: state
+    entity_id: !input my_sensor
+    attribute: strikes
+    id: MLB Strikes Change
+
 
 
 condition: [ ]
@@ -507,6 +544,8 @@ action:
                     - MLB First Base Change
                     - MLB Second Base Change
                     - MLB Third Base Change
+                    - MLB Balls Change
+                    - MLB Strikes Change
                     - Quarter Change
                 - condition: state
                   entity_id: !input my_sensor

--- a/Awtrix NFL Team Scoreboard/awtrix_nfl_team_scoreboard.yaml
+++ b/Awtrix NFL Team Scoreboard/awtrix_nfl_team_scoreboard.yaml
@@ -254,6 +254,18 @@ variables:
     {% else %}
       {{ raw_score|string }}
     {% endif %}
+  left_team_score_x: >-
+    {% if left_team_score|string|length == 1 %}
+      11
+    {% else %}
+      7
+    {% endif %}
+  right_team_score_x: >-
+    {% if right_team_score|string|length == 1 %}
+      18
+    {% else %}
+      18
+    {% endif %}
   team_colors_0: >-
     {% if state_attr(my_sensor, 'team_abbr') == 'CAN' %}#D80621
     {% elif state_attr(my_sensor, 'team_abbr') == 'SWE' %}#006AA7
@@ -347,8 +359,8 @@ variables:
         {"dl":[28,0,28,7,"{{ right_team_colors_1 }}"]}, 
         {"dl":[30,0,30,7,"{{ right_team_colors_1 }}"]}, 
         {{ first_quarter }}
-        {"dt":[7, 1, "{{ left_team_score }}",[255,255,255]]}, 
-        {"dt":[18, 1, "{{ right_team_score }}",[255,255,255]]}, 
+        {"dt":[{{ left_team_score_x }}, 1, "{{ left_team_score }}",[255,255,255]]}, 
+        {"dt":[{{ right_team_score_x }}, 1, "{{ right_team_score }}",[255,255,255]]}, 
         {"dl":[15,3,16,3,"#ffffff"]} 
       ], 
       "duration": {{ message_duration }} 
@@ -363,8 +375,8 @@ variables:
         {"dl":[28,0,28,7,"{{ right_team_colors_1 }}"]}, 
         {"dl":[30,0,30,7,"{{ right_team_colors_1 }}"]}, 
         {{ second_quarter }}
-        {"dt":[7, 1, "{{ left_team_score }}",[255,255,255]]}, 
-        {"dt":[18, 1, "{{ right_team_score }}",[255,255,255]]}, 
+        {"dt":[{{ left_team_score_x }}, 1, "{{ left_team_score }}",[255,255,255]]}, 
+        {"dt":[{{ right_team_score_x }}, 1, "{{ right_team_score }}",[255,255,255]]}, 
         {"dl":[15,3,16,3,"#ffffff"]} 
       ], 
       "duration": {{ message_duration }} 
@@ -379,8 +391,8 @@ variables:
         {"dl":[28,0,28,7,"{{ right_team_colors_1 }}"]}, 
         {"dl":[30,0,30,7,"{{ right_team_colors_1 }}"]}, 
         {{ third_quarter }}
-        {"dt":[7, 1, "{{ left_team_score }}",[255,255,255]]}, 
-        {"dt":[18, 1, "{{ right_team_score }}",[255,255,255]]}, 
+        {"dt":[{{ left_team_score_x }}, 1, "{{ left_team_score }}",[255,255,255]]}, 
+        {"dt":[{{ right_team_score_x }}, 1, "{{ right_team_score }}",[255,255,255]]}, 
         {"dl":[15,3,16,3,"#ffffff"]} 
       ], 
       "duration": {{ message_duration }} 
@@ -395,8 +407,8 @@ variables:
         {"dl":[28,0,28,7,"{{ right_team_colors_1 }}"]}, 
         {"dl":[30,0,30,7,"{{ right_team_colors_1 }}"]}, 
         {{ fourth_quarter }}
-        {"dt":[7, 1, "{{ left_team_score }}",[255,255,255]]}, 
-        {"dt":[18, 1, "{{ right_team_score }}",[255,255,255]]}, 
+        {"dt":[{{ left_team_score_x }}, 1, "{{ left_team_score }}",[255,255,255]]}, 
+        {"dt":[{{ right_team_score_x }}, 1, "{{ right_team_score }}",[255,255,255]]}, 
         {"dl":[15,3,16,3,"#ffffff"]} 
       ], 
       "duration": {{ message_duration }} 

--- a/Awtrix NFL Team Scoreboard/awtrix_nfl_team_scoreboard.yaml
+++ b/Awtrix NFL Team Scoreboard/awtrix_nfl_team_scoreboard.yaml
@@ -133,6 +133,13 @@ blueprint:
             - label: "Traditional"
               value: "home_team_right"
 
+    score_leading_zero:
+      name: Leading Zero
+      description: "Display a leading zero for scores < 10 (e.g., 07 vs 7)"
+      default: true
+      selector:
+        boolean:
+
   source_url: https://raw.githubusercontent.com/jlongman/Homeassistant_blueprints/main/Awtrix%20NFL%20Team%20Scoreboard/awtrix_nfl_team_scoreboard.yaml
 
 variables:
@@ -157,6 +164,7 @@ variables:
   timezone_regex: " ?[A-Z][SD]T"
   my_timer_1st_2nd_intermission: !input my_timer_1st_2nd_intermission
   my_timer_overtime_intermission: !input my_timer_overtime_intermission
+  score_leading_zero: !input score_leading_zero
   intermission_1st_time: "{{ my_timer_1st_2nd_intermission }}"
   intermission_3rd_time: "{% if my_timer_overtime_intermission > 0 %}{{ my_timer_overtime_intermission }}{% else %}{{ my_timer_1st_2nd_intermission }}{% endif %}"
   is_swapped: "{% if display_mode == 'home_team_right' %}{{ state_attr(my_sensor, 'team_homeaway') == 'home' }}{% else %}false{% endif %}"
@@ -230,7 +238,7 @@ variables:
     {% else %}
       {% set raw_score = state_attr(my_sensor, 'team_score') %}
     {% endif %}
-    {% if raw_score|int < 10 %}
+    {% if score_leading_zero and raw_score|int < 10 %}
       {{ "0" + raw_score|string }}
     {% else %}
       {{ raw_score|string }}
@@ -241,7 +249,7 @@ variables:
     {% else %}
       {% set raw_score = state_attr(my_sensor, 'opponent_score') %}
     {% endif %}
-    {% if raw_score|int < 10 %}
+    {% if score_leading_zero and raw_score|int < 10 %}
       {{ "0" + raw_score|string }}
     {% else %}
       {{ raw_score|string }}
@@ -278,14 +286,14 @@ variables:
   game_clock: "{{ state_attr(my_sensor, 'clock') }}"
   team_score: >-
     {% set raw_team_score = state_attr(my_sensor, 'team_score') %}
-    {% if raw_team_score|int < 10 %}
+    {% if score_leading_zero and raw_team_score|int < 10 %}
       {{  "0" + raw_team_score|string }}
     {% else %}
         {{ raw_team_score|string }}
     {% endif %}
   opponent_score: >-
     {% set raw_opponent_score = state_attr(my_sensor, 'opponent_score') %}
-    {% if raw_opponent_score|int < 10 %}
+    {% if score_leading_zero and raw_opponent_score|int < 10 %}
         {{ "0" + raw_opponent_score|string }}
     {% else %}
         {{ raw_opponent_score|string }}


### PR DESCRIPTION
This pull request enhances the `Awtrix MLB Team Scoreboard` by adding real-time display and trigger support for MLB balls and strikes, and refines how scores and display elements are rendered. The changes improve the accuracy and visual feedback of the scoreboard, especially for balls/strikes count and custom score rendering.

**MLB Balls and Strikes Support:**

- Added variables `mlb_balls` and `mlb_strikes` to extract balls and strikes from the sensor attributes, defaulting to 0 if not available.
- Introduced `balls_display` and `strikes_display` variables to visually represent the current count of balls and strikes on the scoreboard, using colored display points.
- Appended `balls_display` and `strikes_display` into the main scoreboard display sequence, ensuring these are shown during active play.

**Trigger and Action Updates:**

- Added new triggers for changes in the `balls` and `strikes` attributes, so the scoreboard updates immediately when these values change.
- Included the new triggers (`MLB Balls Change`, `MLB Strikes Change`) in the automation actions to ensure proper refresh on relevant events.

**Score Rendering Improvements:**

- Simplified custom rendering for single-digit scores and added explicit handling for a score of 11, improving clarity and consistency for both left and right team scores. [[1]](diffhunk://#diff-f1c3e02798ca5fbdf4450e0981d35d4f257c60d20c981d6989d5144067c32799L277-R314) [[2]](diffhunk://#diff-f1c3e02798ca5fbdf4450e0981d35d4f257c60d20c981d6989d5144067c32799L298-R334)

**Other Display Adjustments:**

- Removed an unused green display point (`{"dp":[16,0,"#00FF00"]}`) from the scoreboard background rendering for a cleaner look.
- Removed color indicator logic for swapped teams at the beginning of the display sequence, likely to streamline the visual output.